### PR TITLE
fix(roomallocator): Fix the incorrect default value setting for departure.

### DIFF
--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -216,7 +216,7 @@ func (r *StandardRoomAllocator) applyNamedRoomConfiguration(req *livekit.CreateR
 		clone.EmptyTimeout = conf.EmptyTimeout
 	}
 	if clone.DepartureTimeout == 0 {
-		clone.DepartureTimeout = req.DepartureTimeout
+		clone.DepartureTimeout = conf.DepartureTimeout
 	}
 	if clone.MaxParticipants == 0 {
 		clone.MaxParticipants = conf.MaxParticipants


### PR DESCRIPTION
- Change the default departure value from DepartureTimeout in the request to DepartureTimeout in the configuration.
- Ensure that when clone.DepartureTimeout is 0, the default value set in the configuration file is used.